### PR TITLE
Update .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "riak_pb"]
 	path = riak_pb
-	url = git://github.com/basho/riak_pb.git
+	url = https://github.com/basho/riak_pb.git
 [submodule "tools"]
 	path = tools
-	url = git://github.com/basho/riak-client-tools.git
+	url = https://github.com/basho/riak-client-tools.git


### PR DESCRIPTION
go get by default using https to access github but the submodule clone fails on systems that have firewalls blocking ssh traffic to internet

Please ensure the following is present in your Pull Request:

- [x] Unit tests for your change
- [ ] Integration tests (if applicable)

Pull Requests that are small and limited in scope are most welcome.

Thank you!
